### PR TITLE
now uses new project name in store

### DIFF
--- a/add/backend/addBackend.js
+++ b/add/backend/addBackend.js
@@ -28,24 +28,24 @@ const routes = loadFile('backend/common/routes.js')
 
 const createBackend = async (mode, serverTestingSelection, databaseSelection) => {
   try {
-    helpers.mkdirSync('./server')
+    helpers.mkdirSync('server')
   } catch (err) {
     console.error('Server folder already exists')
     process.exit(1)
   }
-  helpers.mkdirSync('./server/models')
-  helpers.mkdirSync('./server/controllers')
-  helpers.mkdirSync('./server/helpers')
+  helpers.mkdirSync('server/models')
+  helpers.mkdirSync('server/controllers')
+  helpers.mkdirSync('server/helpers')
   if (mode !== 'api') {
     try {
-      helpers.mkdirSync('./assets')
+      helpers.mkdirSync('assets')
     } catch (err) {
       console.error('Tried to create assets folder but one already exists')
     }
   }
 
-  helpers.writeFile('./server/routes.js', routes)
-  helpers.writeFile('./server/cluster.js', cluster)
+  helpers.writeFile('server/routes.js', routes)
+  helpers.writeFile('server/cluster.js', cluster)
 
   mode.mode === 'standard' ? standard() : mode.mode === 'mvc' ? mvc() : api()
 
@@ -61,11 +61,11 @@ const standard = () => {
   const server = loadFile('backend/standard/server.js')
   const controller = loadFile('backend/standard/home.js')
 
-  helpers.writeFile('./server/server.js', server)
-  helpers.writeFile('./server/controllers/home.js', controller)
-  helpers.mkdirSync('./server/views')
-  helpers.mkdirSync('./server/views/home')
-  helpers.writeFile('./server/views/home/index.html', html)
+  helpers.writeFile('server/server.js', server)
+  helpers.writeFile('server/controllers/home.js', controller)
+  helpers.mkdirSync('server/views')
+  helpers.mkdirSync('server/views/home')
+  helpers.writeFile('server/views/home/index.html', html)
 }
 
 const mvc = () => {
@@ -75,23 +75,23 @@ const mvc = () => {
   const pug = loadFile('backend/mvc/index.pug')
   const controller = loadFile('backend/mvc/home.js')
 
-  helpers.writeFile('./server/server.js', server)
+  helpers.writeFile('server/server.js', server)
 
-  helpers.mkdirSync('./server/views')
-  helpers.writeFile('./server/views/error.pug', error)
-  helpers.writeFile('./server/views/layout.pug', layout)
-  helpers.mkdirSync('./server/views/home')
-  helpers.writeFile('./server/views/home/index.pug', pug)
+  helpers.mkdirSync('server/views')
+  helpers.writeFile('server/views/error.pug', error)
+  helpers.writeFile('server/views/layout.pug', layout)
+  helpers.mkdirSync('server/views/home')
+  helpers.writeFile('server/views/home/index.pug', pug)
 
-  helpers.writeFile('./server/controllers/home.js', controller)
+  helpers.writeFile('server/controllers/home.js', controller)
 }
 
 const api = () => {
   const server = loadFile('backend/api/server.js')
   const homeController = loadFile('backend/api/home.js')
 
-  helpers.writeFile('./server/server.js', server)
-  helpers.writeFile('./server/controllers/home.js', homeController)
+  helpers.writeFile('server/server.js', server)
+  helpers.writeFile('server/controllers/home.js', homeController)
 }
 
 const packages = mode => {
@@ -128,9 +128,9 @@ const scripts = mode => {
   helpers.addScript('server', 'nodemon server/cluster.js')
   // controller script
   helpers.addScript('controller', 'node scripts/controller.js')
-  helpers.writeFile('./scripts/controller.js', controller)
-  helpers.writeFile('./scripts/templates/controller.js', controllerTemplate)
-  helpers.writeFile('./scripts/templates/routes.js', routesTemplate)
+  helpers.writeFile('scripts/controller.js', controller)
+  helpers.writeFile('scripts/templates/controller.js', controllerTemplate)
+  helpers.writeFile('scripts/templates/routes.js', routesTemplate)
 
   if (mode === 'mvc') {
     pugScript()
@@ -145,12 +145,12 @@ const pageScript = () => {
 
   if (helpers.checkIfScriptIsTaken('view')) {
    helpers.addScript('server:view', 'node scripts/page') 
-   helpers.writeFile('./scripts/page.js', script)
+   helpers.writeFile('scripts/page.js', script)
   } else {
     helpers.addScript('view', 'node scripts/view.js')
-    helpers.writeFile('./scripts/view.js', script)
+    helpers.writeFile('scripts/view.js', script)
   }
-  helpers.writeFile('./scripts/templates/index.html', htmlTemplate)
+  helpers.writeFile('scripts/templates/index.html', htmlTemplate)
 }
 
 const pugScript = () => {
@@ -160,12 +160,12 @@ const pugScript = () => {
   if (helpers.checkIfScriptIsTaken('view')) {
     // view script is taken
     helpers.addScript('server:view', 'node scripts/pug.js')
-    helpers.writeFile('./scripts/pug.js', script)
+    helpers.writeFile('scripts/pug.js', script)
   } else {
     helpers.addScript('view', 'node scripts/view.js')
-    helpers.writeFile('./scripts/view.js', script)
+    helpers.writeFile('scripts/view.js', script)
   }
-  helpers.writeFile('./scripts/templates/pugTemplate.pug', pugTemplate)
+  helpers.writeFile('scripts/templates/pugTemplate.pug', pugTemplate)
 }
 
 module.exports = addBackend

--- a/add/backend/addBackendTests.js
+++ b/add/backend/addBackendTests.js
@@ -9,7 +9,7 @@ const loadFile = filePath => {
 
 const checkOrCreateServerTestFolder = () => {
   if (!fs.existsSync(`./test/server`)) {
-    helpers.mkdirSync(`./test/server`)
+    helpers.mkdirSync(`test/server`)
   }
 }
 
@@ -18,7 +18,7 @@ const mochaTestBackend = () => {
   helpers.addScript('mocha', 'mocha test/server')
   checkOrCreateServerTestFolder()
   helpers.writeFile(
-    `./test/server/test.spec.js`,
+    `test/server/test.spec.js`,
     loadFile('testing/backend/mocha.js')
   )
   let json = JSON.parse(fs.readFileSync(`./package.json`, 'utf8'))
@@ -30,14 +30,14 @@ const mochaTestBackend = () => {
     ]
   }
   let newPackage = JSON.stringify(json, null, 2)
-  fs.writeFileSync(`./package.json`, newPackage)
+  fs.writeFileSync(`package.json`, newPackage)
 }
 
 const testJestBackend = () => {
   helpers.addDevDependenciesToStore('jest supertest')
   checkOrCreateServerTestFolder()
   helpers.writeFile(
-    `./test/server/test.spec.js`,
+    `test/server/test.spec.js`,
     loadFile('testing/backend/jest.js')
   )
   let json = JSON.parse(fs.readFileSync(`./package.json`, 'utf8'))
@@ -53,7 +53,7 @@ const testJestBackend = () => {
     json['jest'] = jest
   }
   let newPackage = JSON.stringify(json, null, 2)
-  fs.writeFileSync(`./package.json`, newPackage)
+  fs.writeFileSync(`package.json`, newPackage)
   helpers.addScript('jest', 'jest')
 }
 

--- a/add/backend/addBookshelf.js
+++ b/add/backend/addBookshelf.js
@@ -20,11 +20,11 @@ const addBookshelfToScripts = async () => {
   const bookshelfModel = loadFile('backend/models/bookshelf.js')
 
   // write loaded files to new project
-  helpers.writeFile(`./server/models/bookshelf.js`, bookshelfModel)
+  helpers.writeFile(`server/models/bookshelf.js`, bookshelfModel)
   // the following files are loaded into the scripts folder
-  helpers.writeFile(`./scripts/model.js`, bookshelf)
-  helpers.writeFile(`./scripts/templates/migration.js`, migration)
-  helpers.writeFile(`./scripts/templates/bookshelf.js`, model)
+  helpers.writeFile(`scripts/model.js`, bookshelf)
+  helpers.writeFile(`scripts/templates/migration.js`, migration)
+  helpers.writeFile(`scripts/templates/bookshelf.js`, model)
 
   helpers.addScript('model', 'node scripts/model.js')
   installKnexGlobal()

--- a/add/backend/addMongoDB.js
+++ b/add/backend/addMongoDB.js
@@ -1,7 +1,7 @@
 const path = require('path')
 const fs = require('fs')
 const helpers = require('../../helpers')
-
+const store = require('../../new/store')
 const loadFile = filePath => {
   let root = '../../new/files/'
   return fs.readFileSync(path.resolve(__dirname, root + filePath), 'utf8')
@@ -12,26 +12,18 @@ const addMongooseToScripts = () => {
   helpers.checkScriptsFolderExist()
   let model = loadFile('scripts/backend/mongoose.js')
   let schemaTemplate = loadFile('scripts/backend/templates/mongoose.js')
-  helpers.writeFile(`./scripts/model.js`, model)
-  helpers.writeFile(`./scripts/templates/schemaTemplate.js`, schemaTemplate)
+
+  helpers.writeFile(`scripts/model.js`, model)
+  helpers.writeFile(`scripts/templates/schemaTemplate.js`, schemaTemplate)
 
   helpers.addScript('model', 'node scripts/model.js')
   addMongoDBToProject()
 }
 
 const addMongoDBToProject = () => {
-  let server = fs
-    .readFileSync(`./server/server.js`, 'utf8')
-    .toString()
-    .split('\n')
-  server.splice(
-    0,
-    0,
-    `const mongoose = require('mongoose')\nmongoose.connect(process.env.MONGO, { useNewUrlParser: true })\n`
-  )
-  let mongoAddedServer = server.join('\n')
+  let connectionString = `const mongoose = require('mongoose')\nmongoose.connect(process.env.MONGO, { useNewUrlParser: true })\n`
+  helpers.insert(`./${store.name}/server/server.js`, connectionString, 0)
 
-  helpers.writeFile(`./server/server.js`, mongoAddedServer)
   envFileExists()
   helpers.addDependenciesToStore('mongo mongoose')
 }
@@ -42,7 +34,7 @@ const envFileExists = () => {
     if (fs.existsSync('./.env')) {
       helpers.appendFile('./.env', `\nMONGO=${`mongodb://localhost:27017/${name}`}`)
     } else {
-      helpers.writeFile('./.env', `MONGO=${`mongodb://localhost:27017/${name}`}`)
+      helpers.writeFile('.env', `MONGO=${`mongodb://localhost:27017/${name}`}`)
     }
   } catch (err) {
     console.error('Failed to find, create or append .env file')

--- a/add/react-router/addReactRouter.js
+++ b/add/react-router/addReactRouter.js
@@ -52,28 +52,28 @@ let projectType = async () => {
 }
 
 let createView = type => {
-    helpers.mkdirSync('./src/views')
+    helpers.mkdirSync('src/views')
 
     if (type === 'redux') {
         let homeView = loadFile('frontend/react-router/HomeAppContainerView.js')
-        helpers.writeFile('./src/views/Home.js', homeView)
+        helpers.writeFile('src/views/Home.js', homeView)
     } else if (type === 'unknown') {
         let homeView = fs.readFileSync(path.resolve(__dirname, './HomeViewBasic.js'), 'utf8')
-        helpers.writeFile('./src/views/Home.js', homeView)
+        helpers.writeFile('src/views/Home.js', homeView)
     } else {
         let homeView = loadFile('frontend/react-router/HomeAppView.js')
-        helpers.writeFile('./src/views/Home.js', homeView)
+        helpers.writeFile('src/views/Home.js', homeView)
     }
 
     let AppRouter = loadFile('frontend/react-router/Router.js')
-    helpers.writeFile('./src/Router.js', AppRouter)
+    helpers.writeFile('src/Router.js', AppRouter)
 
     if (type === 'redux') {
         let index = loadFile('frontend/reactRouter-redux/index.js')
-        helpers.writeFile('./src/index.js', index)
+        helpers.writeFile('src/index.js', index)
     } else {
         let index = loadFile('frontend/react-router/index.js')
-        helpers.writeFile('./src/index.js', index)
+        helpers.writeFile('src/index.js', index)
     }
 
     // scripts
@@ -84,15 +84,15 @@ let createView = type => {
             let stateful = loadFile('scripts/frontend/react/templates/statefulComponent.js')
             let stateless = loadFile('scripts/frontend/react/templates/statelessComponent.js')
     
-            helpers.writeFile('./scripts/templates/statelessComponent.js', stateless)
-            helpers.writeFile('./scripts/templates/statefulComponent.js', stateful)
+            helpers.writeFile('scripts/templates/statelessComponent.js', stateless)
+            helpers.writeFile('scripts/templates/statefulComponent.js', stateful)
 
             if (type === 'redux') {
                 let componentScript = loadFile('scripts/frontend/reactRouter-redux/component.js')
-                helpers.writeFile('./scripts/component.js', componentScript)
+                helpers.writeFile('scripts/component.js', componentScript)
             } else {
                let componentScript = loadFile('scripts/frontend/react-router/component.js') 
-               helpers.writeFile('./scripts/component.js', componentScript)
+               helpers.writeFile('scripts/component.js', componentScript)
             }
 
             helpers.addScript('component', 'node scripts/component.js')
@@ -100,10 +100,10 @@ let createView = type => {
     } else {
         if (type === 'redux') {
             let componentScript = loadFile('scripts/frontend/reactRouter-redux/component.js')
-            helpers.writeFile('./scripts/component.js', componentScript)
+            helpers.writeFile('scripts/component.js', componentScript)
         } else {
            let componentScript = loadFile('scripts/frontend/react-router/component.js') 
-           helpers.writeFile('./scripts/component.js', componentScript) 
+           helpers.writeFile('scripts/component.js', componentScript) 
         }
     }
 
@@ -111,41 +111,41 @@ let createView = type => {
     if (type === 'redux') {
         // redux type script
         let viewScript = loadFile('scripts/frontend/reactRouter-redux/view.js')
-        helpers.writeFile('./scripts/view.js', viewScript)
+        helpers.writeFile('scripts/view.js', viewScript)
         helpers.addScript('view', 'node scripts/view.js')
     } else if (type !== 'unknown') {
         // need to check if components script and templates already exist
         let viewScript = loadFile('scripts/frontend/react-router/view.js')
-        helpers.writeFile('./scripts/view.js', viewScript)
+        helpers.writeFile('scripts/view.js', viewScript)
         helpers.addScript('view', 'node scripts/view.js')
     }
 
     // redux action script update
     if (type === 'redux' && helpers.checkIfScriptIsTaken('action')) {
         let newActionScript = loadFile('scripts/frontend/reactRouter-redux/action.js')
-        helpers.writeFile('./scripts/action.js', newActionScript)
+        helpers.writeFile('scripts/action.js', newActionScript)
     }
 }
 
 let blixRedux = () => {
-    helpers.mkdirSync('./src/components')
-    helpers.mkdirSync('./src/components/App')
+    helpers.mkdirSync('src/components')
+    helpers.mkdirSync('src/components/App')
     helpers.moveAllFilesInDir('./src/App', './src/components/App')
 
     createView('redux')
 }
 
 let blixReact = () => {
-    helpers.mkdirSync('./src/components')
-    helpers.mkdirSync('./src/components/App')
+    helpers.mkdirSync('src/components')
+    helpers.mkdirSync('src/components/App')
     helpers.moveAllFilesInDir('./src/App', './src/components/App')
 
     createView()
 }
 
 let createReactApp = () => {
-    helpers.mkdirSync('./src/components')
-    helpers.mkdirSync('./src/components/App')
+    helpers.mkdirSync('src/components')
+    helpers.mkdirSync('src/components/App')
 
     helpers.rename('./src/App.js', './src/components/App/App.js')
     if (fs.existsSync('./src/App.css')) {

--- a/add/redux/addRedux.js
+++ b/add/redux/addRedux.js
@@ -28,11 +28,11 @@ let view   = loadFile('scripts/frontend/reactRouter-redux/view.js')
 
 let redux = () => {
   if (fs.existsSync('./src') && !fs.existsSync('./src/actions')) {
-    helpers.mkdirSync('./src/actions')
-    helpers.writeFile('./src/actions/index.js', '')
-    helpers.mkdirSync('./src/reducers')
-    helpers.writeFile('./src/reducers/rootReducer.js', rootReducer)
-    helpers.writeFile('./src/configStore.js', configStore)
+    helpers.mkdirSync('src/actions')
+    helpers.writeFile('src/actions/index.js', '')
+    helpers.mkdirSync('src/reducers')
+    helpers.writeFile('src/reducers/rootReducer.js', rootReducer)
+    helpers.writeFile('src/configStore.js', configStore)
   } else {
     console.log('No src folder found or src/actions folder already exists.')
     process.exit()
@@ -42,7 +42,7 @@ let redux = () => {
 // creates an index.js file that imports the App.js router and creates store provider
 let createIndex = () => {
   fs.truncateSync('./src/index.js', 0)
-  helpers.writeFile('./src/index.js', index)
+  helpers.writeFile('src/index.js', index)
 }
 
 let createContainer = (name) => {
@@ -59,30 +59,30 @@ let createScripts = () => {
   helpers.addScript('view', 'node scripts/view.js')
   // write scripts and templates
   let file = loadFile('scripts/frontend/redux/component.js')
-  helpers.writeFile('./scripts/component.js', file)
-  helpers.writeFile('./scripts/templates/statelessComponent.js', statelessComponent)
-  helpers.writeFile('./scripts/templates/container.js', container)
-  helpers.writeFile('./scripts/templates/statefulComponent.js', statefulComponent)
-  helpers.writeFile('./scripts/templates/reducer.js', reducerTemplate)
-  helpers.writeFile('./scripts/templates/action.js', actionTemplate)
-  helpers.writeFile('./scripts/action.js', action)
-  helpers.writeFile('./scripts/view.js', view)
+  helpers.writeFile('scripts/component.js', file)
+  helpers.writeFile('scripts/templates/statelessComponent.js', statelessComponent)
+  helpers.writeFile('scripts/templates/container.js', container)
+  helpers.writeFile('scripts/templates/statefulComponent.js', statefulComponent)
+  helpers.writeFile('scripts/templates/reducer.js', reducerTemplate)
+  helpers.writeFile('scripts/templates/action.js', actionTemplate)
+  helpers.writeFile('scripts/action.js', action)
+  helpers.writeFile('scripts/view.js', view)
 }
 
 // option add router selected, and was created with create-react-app
 let createReactApp = () => {
   createIndex()
-  helpers.mkdirSync('./src/components')
-  helpers.mkdirSync('./src/components/App')
-  helpers.mkdirSync('./src/views')
+  helpers.mkdirSync('src/components')
+  helpers.mkdirSync('src/components/App')
+  helpers.mkdirSync('src/views')
   
   helpers.rename('./src/App.js', './src/components/App/App.js')
 
   let router = loadFile('frontend/react-router/Router.js')
-  helpers.writeFile('./src/Router.js', router)
+  helpers.writeFile('src/Router.js', router)
   
   let AppContainer = createContainer('App')
-  helpers.writeFile(`./src/components/App/AppContainer.js`, AppContainer)
+  helpers.writeFile(`src/components/App/AppContainer.js`, AppContainer)
   if (fs.existsSync('./src/App.css')) {
     helpers.rename('./src/App.css', './src/components/App/App.css')
   }
@@ -92,21 +92,21 @@ let createReactApp = () => {
   if (fs.existsSync('./src/App.test.js')) {
     helpers.rename('./src/App.test.js', './src/components/App/App.test.js')
   }
-  helpers.writeFile('./src/views/Home.js', homeView) 
+  helpers.writeFile('src/views/Home.js', homeView) 
   createScripts()
 }
 
 // add router option selected and created by blix
 let basicReactCreatedByBlix = () => {
   let router = loadFile('frontend/react-router/Router.js')
-  helpers.writeFile('./src/Router.js', router)
+  helpers.writeFile('src/Router.js', router)
 
   helpers.rename('./src/App/App.js', './src/components/App/App.js')
   let AppContainer = createContainer('App')
-  helpers.writeFile(`./src/components/App/AppContainer.js`, AppContainer)
+  helpers.writeFile(`src/components/App/AppContainer.js`, AppContainer)
   helpers.rename('./src/App/App.css', './src/components/App/App.css')
 
-  helpers.writeFile('./src/views/Home.js', homeView)
+  helpers.writeFile('src/views/Home.js', homeView)
   try {
     fs.rmdirSync('./src/App')
   } catch (err) {
@@ -120,7 +120,7 @@ let reactRouterCreatedByBlix = () => {
   filesInComponents.forEach(file => {
     if (fs.lstatSync(`./src/components/${file}`).isDirectory()) {
       let container = createContainer(file)
-      helpers.writeFile(`./src/components/${file}/${file}Container.js`, container)
+      helpers.writeFile(`src/components/${file}/${file}Container.js`, container)
     }
   })
   createIndex()
@@ -135,9 +135,9 @@ let createdByBlix = () => {
   } else {
     // blix basic react style
     createIndex()
-    helpers.mkdirSync('./src/components')
-    helpers.mkdirSync('./src/components/App')
-    helpers.mkdirSync('./src/views')
+    helpers.mkdirSync('src/components')
+    helpers.mkdirSync('src/components/App')
+    helpers.mkdirSync('src/views')
     basicReactCreatedByBlix()
   }
 
@@ -170,18 +170,18 @@ let dontAddReactRouter = async () => {
   } else if (fs.existsSync('./src/App/App.js')) {
     // basic react type blix project
     let AppContainer = createContainer('App')
-    helpers.writeFile('./src/App/AppContainer.js', AppContainer)
+    helpers.writeFile('src/App/AppContainer.js', AppContainer)
     let index = `import React from 'react'\nimport ReactDOM from 'react-dom'\nimport AppContainer from './App/AppContainer'\nimport { configureStore } from './configStore'\nimport { Provider } from 'react-redux'\n\n\nconst store = configureStore()\n\n\nReactDOM.render(\n\t<Provider store={store}>\n\t\t<AppContainer/>\n\t</Provider>\n, document.getElementById('root'))`
 
     fs.truncateSync('./src/index.js', 0)
-    helpers.writeFile('./src/index.js', index)
+    helpers.writeFile('src/index.js', index)
   } else if (fs.existsSync('./src/App.js')) {
     // create-react-app
     let AppContainer = createContainer('App')
-    helpers.writeFile('./src/AppContainer.js', AppContainer)
+    helpers.writeFile('src/AppContainer.js', AppContainer)
     let index = `import React from 'react'\nimport ReactDOM from 'react-dom'\nimport AppContainer from './AppContainer'\nimport { configureStore } from './configStore'\nimport { Provider } from 'react-redux'\n\n\nconst store = configureStore()\n\n\nReactDOM.render(\n\t<Provider store={store}>\n\t\t<AppContainer/>\n\t</Provider>\n, document.getElementById('root'))`
     fs.truncateSync('./src/index.js', 0)
-    helpers.writeFile('./src/index.js', index)
+    helpers.writeFile('src/index.js', index)
   }
   await helpers.installDependenciesToExistingProject('react-redux redux')
 }

--- a/add/webpack/addWebpack.js
+++ b/add/webpack/addWebpack.js
@@ -90,11 +90,11 @@ let createConfig = async (input, output, react) => {
   webpack = webpack.replace(/OUTPUT/g, output)
 
   let postcss = loadFile('../../new/files/frontend/postcss.config.js')
-  helpers.writeFile('./postcss.config.js', postcss, 'Created postcss.config.js')
+  helpers.writeFile('postcss.config.js', postcss, 'Created postcss.config.js')
 
-  helpers.writeFile('./webpack.config.js', webpack, 'Created webpack.config.js')
+  helpers.writeFile('webpack.config.js', webpack, 'Created webpack.config.js')
   if (!fs.existsSync('./.babelrc')) {
-    helpers.writeFile('./.babelrc', babel, 'Created .babelrc')
+    helpers.writeFile('.babelrc', babel, 'Created .babelrc')
   }
 
 

--- a/new/backend.js
+++ b/new/backend.js
@@ -1,7 +1,6 @@
 const fs = require('fs')
 const helpers = require('../helpers')
 const path = require('path')
-const name = process.argv[3]
 const { createCommonFilesAndFolders } = require('./utils/createCommonFiles')
 const { testBackend } = require('./utils/addBackendTests')
 const { addMongooseToScripts } = require('./utils/addMongoDB')
@@ -23,17 +22,17 @@ const createBackend = async () => {
     createCommonFilesAndFolders()
   }
   // create folders
-  helpers.mkdirSync(`./${name}/server`)
-  helpers.mkdirSync(`./${name}/server/models`)
-  helpers.mkdirSync(`./${name}/server/controllers`)
-  helpers.mkdirSync(`./${name}/server/helpers`)
+  helpers.mkdirSync(`server`)
+  helpers.mkdirSync(`server/models`)
+  helpers.mkdirSync(`server/controllers`)
+  helpers.mkdirSync(`server/helpers`)
   if (store.backendType !== 'api') {
-    helpers.mkdirSync(`./${name}/assets`)
+    helpers.mkdirSync(`assets`)
   }
 
   // create files: routes.js cluster.js
-  helpers.writeFile(`./${name}/server/routes.js`, routes)
-  helpers.writeFile(`./${name}/server/cluster.js`, cluster)
+  helpers.writeFile(`server/routes.js`, routes)
+  helpers.writeFile(`server/cluster.js`, cluster)
 
   if (store.backendType === 'standard') {
     // type when there is a frontend framework and for the most part the backend is a soa but serves some assets and files
@@ -70,11 +69,11 @@ const standard = () => {
   let controller = loadFile('./files/backend/standard/home.js')
 
   // mode for when there is a frontend framework
-  helpers.mkdirSync(`./${name}/server/views`)
-  helpers.mkdirSync(`./${name}/server/views/home`)
-  helpers.writeFile(`./${name}/server/views/home/index.html`, html)
-  helpers.writeFile(`./${name}/server/server.js`, server)
-  helpers.writeFile(`./${name}/server/controllers/home.js`, controller)
+  helpers.mkdirSync(`server/views`)
+  helpers.mkdirSync(`server/views/home`)
+  helpers.writeFile(`server/views/home/index.html`, html)
+  helpers.writeFile(`server/server.js`, server)
+  helpers.writeFile(`server/controllers/home.js`, controller)
 }
 
 const mvcType = () => {
@@ -83,22 +82,22 @@ const mvcType = () => {
   const layout = loadFile('./files/backend/mvc/layout.pug')
   const pug = loadFile('./files/backend/mvc/index.pug')
 
-  helpers.mkdirSync(`./${name}/server/views`)
+  helpers.mkdirSync(`server/views`)
 
-  helpers.writeFile(`./${name}/server/views/error.pug`, error)
-  helpers.writeFile(`./${name}/server/views/layout.pug`, layout)
-  helpers.mkdirSync(`./${name}/server/views/home`)
-  helpers.writeFile(`./${name}/server/views/home/index.pug`, pug)
+  helpers.writeFile(`server/views/error.pug`, error)
+  helpers.writeFile(`server/views/layout.pug`, layout)
+  helpers.mkdirSync(`server/views/home`)
+  helpers.writeFile(`server/views/home/index.pug`, pug)
 
-  helpers.writeFile(`./${name}/server/server.js`, server)
+  helpers.writeFile(`server/server.js`, server)
 }
 
 const apiType = () => {
   let server = loadFile('./files/backend/api/server.js')
   let controller = loadFile('./files/backend/api/home.js')
 
-  helpers.writeFile(`./${name}/server/server.js`, server)
-  helpers.writeFile(`./${name}/server/controllers/home.js`, controller)
+  helpers.writeFile(`server/server.js`, server)
+  helpers.writeFile(`server/controllers/home.js`, controller)
 }
 
 const addDatabase = databaseSelection => {
@@ -118,9 +117,9 @@ const scripts = mode => {
   // controller script
   helpers.addScriptToNewPackageJSON('controller', 'node scripts/controller.js')
   // create files
-  helpers.writeFile(`./${name}/scripts/controller.js`, controller)
-  helpers.writeFile(`./${name}/scripts/templates/controller.js`, controllerTemplate)
-  helpers.writeFile(`./${name}/scripts/templates/routes.js`, routesTemplate)
+  helpers.writeFile(`scripts/controller.js`, controller)
+  helpers.writeFile(`scripts/templates/controller.js`, controllerTemplate)
+  helpers.writeFile(`scripts/templates/routes.js`, routesTemplate)
 }
 
 const packages = mode => {
@@ -140,7 +139,11 @@ const packages = mode => {
 }
 
 const envSetup = () => {
-  helpers.appendFile(`./${name}/.env`, '\nWORKERS=1')
+  if (store.name) {
+    helpers.appendFile(`./${store.name}/.env`, '\nWORKERS=1')
+  } else {
+    helpers.appendFile(`./.env`, '\nWORKERS=1')
+  }
 }
 
 module.exports = {

--- a/new/index.js
+++ b/new/index.js
@@ -7,10 +7,11 @@ const { react } = require("./react");
 const { vanillaJS } = require("./vanillaJS");
 let store = require('./store')
 
-const name = process.argv[3];
+store.name = process.argv[3] || '';
 
 // console prompts
 const {
+  namePrompt,
   defaultOrCustom,
   frontendOptions,
   backend,
@@ -130,18 +131,24 @@ const backendOnly = async () => {
   createBackend();
 };
 
+const promptForName = async () => {
+  let answer = await prompt([namePrompt])
+  store.name = answer.name
+  createProject()
+}
+
 // create project ensures there shouldn't be errors before starting the prompts
 const createProject = () => {
-  if (!name) {
-    console.log('No name provided for new project.')
-    console.log('Try again with: blix new my-project')
-    process.exit(1)
+  if (!store.name) {
+    console.clear()
+    promptForName()
+    return
   }
-  if (fs.existsSync(`./${name}`)) {
-    console.error(`A project named ${name} already exists!`);
-    process.exit(1)
+  if (fs.existsSync(`./${store.name}`)) {
+    console.error(`A project named ${store.name} already exists!`);
+    promptForName()
+    return
   }
-  console.clear()
   promptPreset()
 };
 

--- a/new/prompts.js
+++ b/new/prompts.js
@@ -1,5 +1,11 @@
 const chalk = require('chalk')
 
+const namePrompt = {
+  type: 'input',
+  message: 'Please provide a name for your project: ',
+  name: 'name'
+}
+
 const defaultOrCustom = {
   type: "list",
   message: "Please select a preset: ",
@@ -107,6 +113,7 @@ const reactCSS = {
 }
 
 module.exports = {
+  namePrompt,
   defaultOrCustom,
   frontendOptions,
   backend,

--- a/new/react.js
+++ b/new/react.js
@@ -6,7 +6,6 @@ const { installReactTesting } = require("./utils/addReactTesting");
 const { e2eSetup } = require("./utils/addEndToEndTesting");
 const { newProjectInstructions } = require('./utils/newProjectInstructions')
 const { createBackend } = require("./backend");
-const name = process.argv[3];
 const store = require('./store')
 
 const loadFile = filePath => {
@@ -48,18 +47,18 @@ const react = async () => {
   createCommonFilesAndFolders();
 
   // create react files
-  helpers.mkdirSync(`./${name}/dist`);
-  helpers.mkdirSync(`./${name}/src`);
+  helpers.mkdirSync(`dist`);
+  helpers.mkdirSync(`src`);
   // A FOLDER TO HOLD FILES WITH RESOURCE FETCH CALLS TO ONE RESOURCE PER FILE (similar to controllers server side)
-  helpers.mkdirSync(`./${name}/src/services`);
+  helpers.mkdirSync(`src/services`);
 
   // build project specific contents based on type supplied from new/index.js
   createSrcContents();
 
   // create webpack postcssConfig and babelrc files
-  helpers.writeFile(`./${name}/postcss.config.js`, postcssConfig);
-  helpers.writeFile(`./${name}/.babelrc`, babel);
-  helpers.writeFile(`./${name}/webpack.config.js`, webpack);
+  helpers.writeFile(`postcss.config.js`, postcssConfig);
+  helpers.writeFile(`.babelrc`, babel);
+  helpers.writeFile(`webpack.config.js`, webpack);
 
   cssLibrary()
   // react testing setup
@@ -108,72 +107,72 @@ const createSrcContents = () => {
 };
 
 const reactOnly = () => {
-  helpers.mkdirSync(`./${name}/src/App`);
-  helpers.writeFile(`./${name}/src/index.js`, index);
-  helpers.writeFile(`./${name}/src/App/App.js`, app);
-  helpers.writeFile(`./${name}/src/App/App.css`, cssFile);
+  helpers.mkdirSync(`src/App`);
+  helpers.writeFile(`src/index.js`, index);
+  helpers.writeFile(`src/App/App.js`, app);
+  helpers.writeFile(`src/App/App.css`, cssFile);
 };
 
 const reactRouter = () => {
-  helpers.writeFile(`./${name}/src/index.js`, reactRouterIndex);
-  helpers.writeFile(`./${name}/src/Router.js`, appRouter);
+  helpers.writeFile(`src/index.js`, reactRouterIndex);
+  helpers.writeFile(`src/Router.js`, appRouter);
 
-  helpers.mkdirSync(`./${name}/src/components`);
-  helpers.mkdirSync(`./${name}/src/components/Navbar`);
-  helpers.writeFile(`./${name}/src/components/Navbar/Navbar.js`, Navbar);
-  helpers.writeFile(`./${name}/src/components/Navbar/Navbar.css`, NavbarCSS);
-  helpers.mkdirSync(`./${name}/src/views`);
-  helpers.writeFile(`./${name}/src/views/Home.js`, HomeView);
+  helpers.mkdirSync(`src/components`);
+  helpers.mkdirSync(`src/components/Navbar`);
+  helpers.writeFile(`src/components/Navbar/Navbar.js`, Navbar);
+  helpers.writeFile(`src/components/Navbar/Navbar.css`, NavbarCSS);
+  helpers.mkdirSync(`src/views`);
+  helpers.writeFile(`src/views/Home.js`, HomeView);
   // styles folder
-  helpers.mkdirSync(`./${name}/src/styles`);
-  helpers.writeFile(`./${name}/src/styles/global.css`, globalStyle);
+  helpers.mkdirSync(`src/styles`);
+  helpers.writeFile(`src/styles/global.css`, globalStyle);
   // install react-router-dom for src/index.js file
   helpers.addDevDependenciesToStore("react-router-dom");
 };
 
 const redux = () => {
-  helpers.writeFile(`./${name}/src/index.js`, reduxIndex)
-  helpers.mkdirSync(`./${name}/src/App`)
-  helpers.writeFile(`./${name}/src/App/App.js`, app)
-  helpers.writeFile(`./${name}/src/App/AppContainer.js`, reduxAppContainer)
-  helpers.writeFile(`./${name}/src/App/App.css`, cssFile)
+  helpers.writeFile(`src/index.js`, reduxIndex)
+  helpers.mkdirSync(`src/App`)
+  helpers.writeFile(`src/App/App.js`, app)
+  helpers.writeFile(`src/App/AppContainer.js`, reduxAppContainer)
+  helpers.writeFile(`src/App/App.css`, cssFile)
 
-  helpers.mkdirSync(`./${name}/src/actions`)
-  helpers.writeFile(`./${name}/src/actions/index.js`, "")
+  helpers.mkdirSync(`src/actions`)
+  helpers.writeFile(`src/actions/index.js`, "")
 
-  helpers.mkdirSync(`./${name}/src/reducers`)
-  helpers.writeFile(`./${name}/src/reducers/rootReducer.js`, rootReducer);
-  helpers.writeFile(`./${name}/src/configStore.js`, configStore);
+  helpers.mkdirSync(`src/reducers`)
+  helpers.writeFile(`src/reducers/rootReducer.js`, rootReducer);
+  helpers.writeFile(`src/configStore.js`, configStore);
 
   helpers.addDevDependenciesToStore("redux react-redux")
 
 }
 
 const reactRouterRedux = () => {
-  helpers.writeFile(`./${name}/src/index.js`, reactRouterReduxIndex);
-  helpers.writeFile(`./${name}/src/Router.js`, appRouter);
+  helpers.writeFile(`src/index.js`, reactRouterReduxIndex);
+  helpers.writeFile(`src/Router.js`, appRouter);
   // components folder, every component will have a folder with associated css, tests, and/or container for that component
-  helpers.mkdirSync(`./${name}/src/components`);
-  helpers.mkdirSync(`./${name}/src/components/Navbar`);
-  helpers.writeFile(`./${name}/src/components/Navbar/Navbar.js`, Navbar);
+  helpers.mkdirSync(`src/components`);
+  helpers.mkdirSync(`src/components/Navbar`);
+  helpers.writeFile(`src/components/Navbar/Navbar.js`, Navbar);
   helpers.writeFile(
-    `./${name}/src/components/Navbar/NavbarContainer.js`,
+    `src/components/Navbar/NavbarContainer.js`,
     NavbarContainer
   );
-  helpers.writeFile(`./${name}/src/components/Navbar/Navbar.css`, NavbarCSS);
+  helpers.writeFile(`src/components/Navbar/Navbar.css`, NavbarCSS);
   // views folder
-  helpers.mkdirSync(`./${name}/src/views`);
-  helpers.writeFile(`./${name}/src/views/Home.js`, ReduxHomeView);
+  helpers.mkdirSync(`src/views`);
+  helpers.writeFile(`src/views/Home.js`, ReduxHomeView);
   // styles folder for views
-  helpers.mkdirSync(`./${name}/src/styles`);
-  helpers.writeFile(`./${name}/src/styles/global.css`, globalStyle);
+  helpers.mkdirSync(`src/styles`);
+  helpers.writeFile(`src/styles/global.css`, globalStyle);
 
   // need to make actions folder and store file and configure store and reducers folder with rootReducer.js
-  helpers.mkdirSync(`./${name}/src/actions`);
-  helpers.writeFile(`./${name}/src/actions/index.js`, "");
-  helpers.mkdirSync(`./${name}/src/reducers`);
-  helpers.writeFile(`./${name}/src/reducers/rootReducer.js`, rootReducer);
-  helpers.writeFile(`./${name}/src/configStore.js`, configStore);
+  helpers.mkdirSync(`src/actions`);
+  helpers.writeFile(`src/actions/index.js`, "");
+  helpers.mkdirSync(`src/reducers`);
+  helpers.writeFile(`src/reducers/rootReducer.js`, rootReducer);
+  helpers.writeFile(`src/configStore.js`, configStore);
   //install react-router-dom and other redux specific libs
   helpers.addDevDependenciesToStore("redux react-redux react-router-dom");
 };
@@ -184,7 +183,7 @@ const scripts = () => {
       "start",
       "webpack-dev-server --output-public-path=/dist/ --inline --hot --open --port 3000 --mode='development'"
     );
-    helpers.writeFile(`./${name}/index.html`, htmlFile);
+    helpers.writeFile(`index.html`, htmlFile);
   }
   helpers.addScriptToNewPackageJSON(
     "dev",
@@ -208,9 +207,9 @@ const reactScripts = () => {
   let statefulComponentTemplate = loadFile('./files/scripts/frontend/react/templates/statefulComponent.js')
   let statelessComponentTemplate = loadFile("./files/scripts/frontend/react/templates/statelessComponent.js")
 
-  helpers.writeFile(`./${name}/scripts/component.js`, component);
-  helpers.writeFile(`./${name}/scripts/templates/statefulComponent.js`, statefulComponentTemplate);
-  helpers.writeFile(`./${name}/scripts/templates/statelessComponent.js`, statelessComponentTemplate);
+  helpers.writeFile(`scripts/component.js`, component);
+  helpers.writeFile(`scripts/templates/statefulComponent.js`, statefulComponentTemplate);
+  helpers.writeFile(`scripts/templates/statelessComponent.js`, statelessComponentTemplate);
   helpers.addScriptToNewPackageJSON("component", "node scripts/component.js");
 };
 
@@ -220,10 +219,10 @@ const reactRouterScripts = () => {
   let statelessComponentTemplate = loadFile("./files/scripts/frontend/react/templates/statelessComponent.js")
   let view = loadFile('./files/scripts/frontend/react-router/view.js')
 
-  helpers.writeFile(`./${name}/scripts/component.js`, component);
-  helpers.writeFile(`./${name}/scripts/templates/statefulComponent.js`, statefulComponentTemplate);
-  helpers.writeFile(`./${name}/scripts/templates/statelessComponent.js`, statelessComponentTemplate);
-  helpers.writeFile(`./${name}/scripts/view.js`, view);
+  helpers.writeFile(`scripts/component.js`, component);
+  helpers.writeFile(`scripts/templates/statefulComponent.js`, statefulComponentTemplate);
+  helpers.writeFile(`scripts/templates/statelessComponent.js`, statelessComponentTemplate);
+  helpers.writeFile(`scripts/view.js`, view);
   // add scripts to package.json
   helpers.addScriptToNewPackageJSON("component", "node scripts/component.js");
   helpers.addScriptToNewPackageJSON("view", "node scripts/view.js");
@@ -239,14 +238,14 @@ const reduxScripts = () => {
   let statefulComponentTemplate = loadFile("./files/scripts/frontend/react/templates/statefulComponent.js")
 
   // action script and templates
-  helpers.writeFile(`./${name}/scripts/action.js`, action)
-  helpers.writeFile(`./${name}/scripts/templates/action.js`, actionTemplate)
-  helpers.writeFile(`./${name}/scripts/templates/reducer.js`, reducerTemplate)
+  helpers.writeFile(`scripts/action.js`, action)
+  helpers.writeFile(`scripts/templates/action.js`, actionTemplate)
+  helpers.writeFile(`scripts/templates/reducer.js`, reducerTemplate)
   // component script and templates
-  helpers.writeFile(`./${name}/scripts/component.js`, component) 
-  helpers.writeFile(`./${name}/scripts/templates/statelessComponent.js`, statelessComponentTemplate)
-  helpers.writeFile(`./${name}/scripts/templates/container.js`, containerTemplate)
-  helpers.writeFile(`./${name}/scripts/templates/statefulComponent.js`, statefulComponentTemplate)
+  helpers.writeFile(`scripts/component.js`, component) 
+  helpers.writeFile(`scripts/templates/statelessComponent.js`, statelessComponentTemplate)
+  helpers.writeFile(`scripts/templates/container.js`, containerTemplate)
+  helpers.writeFile(`scripts/templates/statefulComponent.js`, statefulComponentTemplate)
 
   // add scripts for action and component to package.json
   helpers.addScriptToNewPackageJSON('component', 'node scripts/component.js')
@@ -263,16 +262,16 @@ const reactRouterReduxScripts = () => {
   let statefulComponentTemplate = loadFile("./files/scripts/frontend/react/templates/statefulComponent.js")
   let view = loadFile('./files/scripts/frontend/reactRouter-redux/view.js')
   // action script and templates
-  helpers.writeFile(`./${name}/scripts/action.js`, action)
-  helpers.writeFile(`./${name}/scripts/templates/action.js`, actionTemplate);
-  helpers.writeFile(`./${name}/scripts/templates/reducer.js`, reducerTemplate);
+  helpers.writeFile(`scripts/action.js`, action)
+  helpers.writeFile(`scripts/templates/action.js`, actionTemplate);
+  helpers.writeFile(`scripts/templates/reducer.js`, reducerTemplate);
   // component script and templates
-  helpers.writeFile(`./${name}/scripts/component.js`, component);
-  helpers.writeFile(`./${name}/scripts/templates/statelessComponent.js`, statelessComponentTemplate);
-  helpers.writeFile(`./${name}/scripts/templates/container.js`, containerTemplate);
-  helpers.writeFile(`./${name}/scripts/templates/statefulComponent.js`, statefulComponentTemplate);
+  helpers.writeFile(`scripts/component.js`, component);
+  helpers.writeFile(`scripts/templates/statelessComponent.js`, statelessComponentTemplate);
+  helpers.writeFile(`scripts/templates/container.js`, containerTemplate);
+  helpers.writeFile(`scripts/templates/statefulComponent.js`, statefulComponentTemplate);
   // view script
-  helpers.writeFile(`./${name}/scripts/view.js`, view);
+  helpers.writeFile(`scripts/view.js`, view);
 
   // add scripts for action and component to package.json
   helpers.addScriptToNewPackageJSON("component", "node scripts/component.js");

--- a/new/store.js
+++ b/new/store.js
@@ -1,4 +1,5 @@
 let store = {
+  name: '',
   frontend: '',
   backend: '',
   backendType: '',

--- a/new/utils/addBackendTests.js
+++ b/new/utils/addBackendTests.js
@@ -2,15 +2,14 @@ const helpers = require("../../helpers");
 const fs = require("fs");
 const path = require("path");
 const store = require('../store')
-const name = process.argv[3];
 
 const loadFile = filePath => {
   return fs.readFileSync(path.resolve(__dirname, filePath), "utf8");
 };
 
 const checkOrCreateServerTestFolder = () => {
-  if (!fs.existsSync(`./${name}/test/server`)) {
-    helpers.mkdirSync(`./${name}/test/server`);
+  if (!fs.existsSync(`./${store.name}/test/server`)) {
+    helpers.mkdirSync(`test/server`);
   }
 };
 
@@ -18,11 +17,9 @@ const mochaTestBackend = () => {
   helpers.addDevDependenciesToStore("mocha chai chai-http");
   helpers.addScriptToNewPackageJSON("mocha", "mocha test/server");
   checkOrCreateServerTestFolder();
-  helpers.writeFile(
-    `./${name}/test/server/test.spec.js`,
-    loadFile("../files/testing/backend/mocha.js")
-  );
-  let json = JSON.parse(fs.readFileSync(`./${name}/package.json`, "utf8"));
+  helpers.writeFile(`test/server/test.spec.js`, loadFile("../files/testing/backend/mocha.js"))
+
+  let json = JSON.parse(fs.readFileSync(`./${store.name}/package.json`, "utf8"));
   if (json.hasOwnProperty("jest")) {
     json.jest["modulePathIgnorePatterns"] = [
       "<rootDir>/test/e2e/",
@@ -31,17 +28,17 @@ const mochaTestBackend = () => {
     ];
   }
   let newPackage = JSON.stringify(json, null, 2);
-  fs.writeFileSync(`./${name}/package.json`, newPackage);
+  fs.writeFileSync(`package.json`, newPackage);
 };
 
 const testJestBackend = () => {
   helpers.addDevDependenciesToStore("jest supertest");
   checkOrCreateServerTestFolder();
   helpers.writeFile(
-    `./${name}/test/server/test.spec.js`,
+    `test/server/test.spec.js`,
     loadFile("../files/testing/backend/jest.js")
   );
-  let json = JSON.parse(fs.readFileSync(`./${name}/package.json`, "utf8"));
+  let json = JSON.parse(fs.readFileSync(`./${store.name}/package.json`, "utf8"));
   if (!json.hasOwnProperty("jest")) {
     let jest = {
       modulePathIgnorePatterns: ["<rootDir>/test/e2e/", "<rootDir>/cypress"],
@@ -54,7 +51,7 @@ const testJestBackend = () => {
     json["jest"] = jest;
   }
   let newPackage = JSON.stringify(json, null, 2);
-  fs.writeFileSync(`./${name}/package.json`, newPackage);
+  fs.writeFileSync(`package.json`, newPackage);
   helpers.addScriptToNewPackageJSON("jest", "jest");
 };
 

--- a/new/utils/addBookshelf.js
+++ b/new/utils/addBookshelf.js
@@ -17,11 +17,11 @@ const addBookshelfToScripts = () => {
   const bookshelfModel = loadFile("../files/backend/models/bookshelf.js");
 
   // write loaded files to new project
-  helpers.writeFile(`./${name}/server/models/bookshelf.js`, bookshelfModel);
+  helpers.writeFile(`server/models/bookshelf.js`, bookshelfModel);
   // the following files are loaded into the scripts folder
-  helpers.writeFile(`./${name}/scripts/model.js`, bookshelf);
-  helpers.writeFile(`./${name}/scripts/templates/migration.js`, migration);
-  helpers.writeFile(`./${name}/scripts/templates/bookshelf.js`, model);
+  helpers.writeFile(`scripts/model.js`, bookshelf);
+  helpers.writeFile(`scripts/templates/migration.js`, migration);
+  helpers.writeFile(`scripts/templates/bookshelf.js`, model);
 
   helpers.addScriptToNewPackageJSON("model", "node scripts/model.js");
   helpers.installKnexGlobal();

--- a/new/utils/addEndToEndTesting.js
+++ b/new/utils/addEndToEndTesting.js
@@ -1,7 +1,6 @@
 const fs = require("fs");
 const helpers = require("../../helpers");
 const path = require("path");
-const name = process.argv[3];
 const store = require('../store')
 
 const loadFile = filePath => {
@@ -19,10 +18,10 @@ let e2eSetup = () => {
 const installCypress = () => {
   helpers.addScriptToNewPackageJSON("e2e", "cypress open");
   helpers.addDevDependenciesToStore("cypress");
-  helpers.mkdirSync(`./${name}/cypress`);
-  helpers.mkdirSync(`./${name}/cypress/integration`);
+  helpers.mkdirSync(`cypress`);
+  helpers.mkdirSync(`cypress/integration`);
   helpers.writeFile(
-    `./${name}/cypress/integration/test.js`,
+    `cypress/integration/test.js`,
     loadFile("../files/frontend/e2e/cypress.js")
   );
   // let ignore = {
@@ -36,7 +35,7 @@ const installCypress = () => {
       "\\.(css|less)$": "identity-obj-proxy"
     }
   };
-  let json = JSON.parse(fs.readFileSync(`./${name}/package.json`, "utf8"));
+  let json = JSON.parse(fs.readFileSync(`./${store.name}/package.json`, "utf8"));
   if (!json.hasOwnProperty("jest")) {
     json["jest"] = jest;
   } else {
@@ -46,15 +45,15 @@ const installCypress = () => {
     ];
   }
   let newPackage = JSON.stringify(json, null, 2);
-  fs.writeFileSync(`./${name}/package.json`, newPackage);
+  fs.writeFileSync(`package.json`, newPackage);
 };
 
 const installTestCafe = () => {
   helpers.addScriptToNewPackageJSON("e2e", "testcafe chrome test/e2e");
   helpers.addDevDependenciesToStore("testcafe");
-  helpers.mkdirSync(`./${name}/test/e2e`);
+  helpers.mkdirSync(`test/e2e`);
   helpers.writeFile(
-    `./${name}/test/e2e/test.js`,
+    `test/e2e/test.js`,
     loadFile("../files/frontend/e2e/testcafe.js")
   );
   let jest = {
@@ -65,7 +64,7 @@ const installTestCafe = () => {
       "\\.(css|less)$": "identity-obj-proxy"
     }
   };
-  let json = JSON.parse(fs.readFileSync(`./${name}/package.json`, "utf8"));
+  let json = JSON.parse(fs.readFileSync(`./${store.name}/package.json`, "utf8"));
   if (!json.hasOwnProperty("jest")) {
     json["jest"] = jest;
   } else {
@@ -75,7 +74,7 @@ const installTestCafe = () => {
     ];
   }
   let newPackage = JSON.stringify(json, null, 2);
-  fs.writeFileSync(`./${name}/package.json`, newPackage);
+  fs.writeFileSync(`package.json`, newPackage);
 };
 
 module.exports = {

--- a/new/utils/addMongoDB.js
+++ b/new/utils/addMongoDB.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const fs = require("fs");
-const name = process.argv[3];
 const helpers = require("../../helpers");
+const store = require('../store')
 
 const loadFile = filePath => {
   return fs.readFileSync(path.resolve(__dirname, filePath), "utf8");
@@ -13,11 +13,8 @@ const addMongooseToScripts = () => {
   let schemaTemplate = loadFile(
     "../files/scripts/backend/templates/mongoose.js"
   );
-  helpers.writeFile(`./${name}/scripts/model.js`, model);
-  helpers.writeFile(
-    `./${name}/scripts/templates/schemaTemplate.js`,
-    schemaTemplate
-  );
+  helpers.writeFile(`scripts/model.js`, model);
+  helpers.writeFile(`scripts/templates/schemaTemplate.js`, schemaTemplate);
 
   helpers.addScriptToNewPackageJSON("model", "node scripts/model.js");
   addMongoDBToProject();
@@ -25,11 +22,11 @@ const addMongooseToScripts = () => {
 
 const addMongoDBToProject = () => {
   let connectionString = `const mongoose = require('mongoose')\nmongoose.connect(process.env.MONGO, { useNewUrlParser: true })\n`
-  helpers.insert(`./${name}/server/server.js`, connectionString, 0)
+  helpers.insert(`./${store.name}/server/server.js`, connectionString, 0)
 
   helpers.appendFile(
-    `./${name}/.env`,
-    `MONGO=${`mongodb://localhost:27017/${name}`}`
+    `./${store.name}/.env`,
+    `MONGO=${`mongodb://localhost:27017/${store.name}`}`
   );
   helpers.addDependenciesToStore("mongo mongoose")
 };

--- a/new/utils/addReactTesting.js
+++ b/new/utils/addReactTesting.js
@@ -1,7 +1,6 @@
 const helpers = require("../../helpers");
 const fs = require("fs");
 const path = require("path");
-const name = process.argv[3];
 const store = require('../store')
 
 const loadFile = filePath => {
@@ -9,6 +8,7 @@ const loadFile = filePath => {
 };
 
 let installReactTesting = () => {
+  let name = store.name
   let file
   if (!store.reactTesting['enzyme']) {
     return;
@@ -20,7 +20,7 @@ let installReactTesting = () => {
   }
   helpers.addDevDependenciesToStore("jest enzyme enzyme-adapter-react-16 identity-obj-proxy")
   helpers.writeFile(
-    `./${name}/test/${file}`,
+    `test/${file}`,
     loadFile(`../files/frontend/enzyme/${file}`)
   );
 
@@ -34,7 +34,7 @@ let installReactTesting = () => {
   let json = JSON.parse(fs.readFileSync(`./${name}/package.json`, "utf8"));
   json["jest"] = jest;
   let newPackage = JSON.stringify(json, null, 2);
-  fs.writeFileSync(`./${name}/package.json`, newPackage);
+  fs.writeFileSync(`package.json`, newPackage);
   helpers.addScriptToNewPackageJSON("test", "jest");
 };
 

--- a/new/utils/createCommonFiles.js
+++ b/new/utils/createCommonFiles.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const path = require("path");
 const helpers = require("../../helpers");
 const execSync = require('child_process').execSync;
-const name = process.argv[3];
+// const name = process.argv[3];
 const store = require('../store')
 const chalk = require('chalk')
 
@@ -16,9 +16,9 @@ const createCommonFilesAndFolders = () => {
     "Creating the project and downloading packages, this may take a moment"
   );
   // creates new project folder first, this is important for all new projects
-  helpers.mkdirSync(`./${name}`);
+  helpers.mkdirSync(``);
   try {
-    process.chdir(`./${name}`)
+    process.chdir(`./${store.name}`)
     execSync('git init')
     process.chdir('../')
   } catch (err) {
@@ -28,25 +28,22 @@ const createCommonFilesAndFolders = () => {
     process.chdir('../')
   }
   helpers.writeFile(
-    `./${name}/.gitignore`,
+    `.gitignore`,
     loadFile("../files/common/gitIgnore.txt")
   );
   helpers.writeFile(
-    `./${name}/README.md`,
+    `README.md`,
     loadFile("../files/common/README.md")
   );
   helpers.writeFile(
-    `./${name}/package.json`,
+    `package.json`,
     loadFile("../files/common/package.json")
   );
 
-  helpers.writeFile(`./${name}/.env`, "");
-  helpers.mkdirSync(`./${name}/scripts`);
-  helpers.mkdirSync(`./${name}/scripts/templates`);
-  helpers.mkdirSync(`./${name}/test`);
-
-  // synchronously adds key value pair of the project name in the name field to package.json
-  // helpers.addKeytoPackageJSON("name", name, name)
+  helpers.writeFile(`.env`, "");
+  helpers.mkdirSync(`scripts`);
+  helpers.mkdirSync(`scripts/templates`);
+  helpers.mkdirSync(`test`);
 };
 
 module.exports = { createCommonFilesAndFolders };

--- a/new/utils/newProjectInstructions.js
+++ b/new/utils/newProjectInstructions.js
@@ -1,12 +1,7 @@
-// need to create a reusable console log of instructions: ie run npm start
-// also need to add the instructions to the README (should be easy)
 const log = console.log;
 const fs = require('fs')
 const store = require('../store')
-const name = process.argv[3];
 const chalk = require('chalk')
-const helpers = require('../../helpers')
-
 const link = 'blixjs.com'
 
 const options = {
@@ -65,7 +60,7 @@ const readmeFormatter = () => {
 
   let readmeOutputString = ('\n' + '## Project Scripts' + '\n\n' + outputString)
   try {
-    fs.appendFileSync(`./${name}/README.md`, readmeOutputString)
+    fs.appendFileSync(`./${store.name}/README.md`, readmeOutputString)
   } catch (err) {
     store.env === 'development' ? log(err) : ""
   }
@@ -82,6 +77,7 @@ const consoleFormatter = () => {
 }
 
 const newProjectInstructions = () => {
+  let name = store.name
   console.clear()
   log("")
   log(`Success! Created new project ${name} at ${process.cwd() + '/' + name}`);

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -119,9 +119,9 @@ const addAction = () => {
   let actionTemplate = loadFile("frontend/redux/templates/action.js");
   let reducerTemplate = loadFile("frontend/redux/templates/reducer.js");
 
-  helpers.writeFile("./scripts/action.js", action, "Created action.js script file in scripts folder");
-  helpers.writeFile("./scripts/templates/action.js", actionTemplate, "Created action template in script/templates");
-  helpers.writeFile("./scripts/templates/reducer.js", reducerTemplate, "Created reducer template in  script/templates");
+  helpers.writeFile("scripts/action.js", action, "Created action.js script file in scripts folder");
+  helpers.writeFile("scripts/templates/action.js", actionTemplate, "Created action template in script/templates");
+  helpers.writeFile("scripts/templates/reducer.js", reducerTemplate, "Created reducer template in  script/templates");
   log("")
   log("Added script to project, to run: npm run action")
   log("This will prompt for the actions name, and the reducers name")
@@ -140,9 +140,9 @@ const addModel = () => {
       let model = loadFile("backend/mongoose.js");
       let schemaTemplate = loadFile("backend/templates/mongoose.js");
 
-      helpers.writeFile("./scripts/model.js", model, "Created model.js script file in scripts folder");
+      helpers.writeFile("scripts/model.js", model, "Created model.js script file in scripts folder");
       helpers.writeFile(
-        "./scripts/templates/schemaTemplate.js",
+        "scripts/templates/schemaTemplate.js",
         schemaTemplate,
         "Created Mongoose schema template in scripts/templates"
       );
@@ -163,20 +163,20 @@ const addModel = () => {
         "backend/bookshelf.js"
       );
       // create files 
-      helpers.writeFile("./scripts/model.js", model, "Created model.js script in scripts folder");
+      helpers.writeFile("scripts/model.js", model, "Created model.js script in scripts folder");
       helpers.writeFile(
-        "./scripts/templates/migration.js",
+        "scripts/templates/migration.js",
         migration,
         "Created knex migration template file in scripts/templates folder"
       );
       helpers.writeFile(
-        "./scripts/templates/bookshelf.js",
+        "scripts/templates/bookshelf.js",
         bookshelf,
         "Created Bookshelf template file in scripts/templates folder"
       );
       // bookshelf required file needs to be placed inside the project, preferably the models folder
       try {
-        helpers.writeFile("./server/models/bookshelf.js", bookshelfRequiredFile);
+        helpers.writeFile("server/models/bookshelf.js", bookshelfRequiredFile);
         log("Created Bookshelf file in server/models/bookshelf.js");
       } catch (e) {
         log(
@@ -197,7 +197,7 @@ let addReact = () => {
   helpers.addScript("component", "node scripts/component.js");
   let react = loadFile("frontend/react/component.js");
   checkScriptsFolderExists();
-  helpers.writeFile("./scripts/component.js", react, "Created component.js script file in scripts folder");
+  helpers.writeFile("scripts/component.js", react, "Created component.js script file in scripts folder");
   checkReactTemplatesExist()
   log("")
   log("Added script to project, to run: npm run component <name>")
@@ -215,9 +215,9 @@ let addRedux = () => {
     "frontend/redux/templates/container.js"
   );
   // write files
-  helpers.writeFile("./scripts/component.js", redux, "Created component.js script file in scripts folder");
+  helpers.writeFile("scripts/component.js", redux, "Created component.js script file in scripts folder");
   helpers.writeFile(
-    "./scripts/templates/container.js",
+    "scripts/templates/container.js",
     container 
   );
   log("")
@@ -232,7 +232,7 @@ let addClientView = () => {
     // if true project uses redux
     if (answer.view) {
       let reduxViewScript = loadFile("frontend/redux/view.js")
-      helpers.writeFile("./scripts/view.js", reduxViewScript, "Created view.js script file in scripts folder")
+      helpers.writeFile("scripts/view.js", reduxViewScript, "Created view.js script file in scripts folder")
       checkReactTemplatesExist()
       log("")
       log("Added script to project, to run: npm run view <name>")
@@ -240,7 +240,7 @@ let addClientView = () => {
       log("If view already exists it will just ask what containers/components from src/components to import into that view.")
     } else {
       let reactRouterViewScript = loadFile("frontend/react-router/view.js")
-      helpers.writeFile("./scripts/view.js", reactRouterViewScript, "Created view.js script file in scripts folder")
+      helpers.writeFile("scripts/view.js", reactRouterViewScript, "Created view.js script file in scripts folder")
       checkReactTemplatesExist()
       log("")
       log("Added script to project, to run: npm run view <name>")
@@ -258,8 +258,8 @@ let checkReactTemplatesExist = () => {
   } catch (err) {
     let statefulComponent = loadFile("frontend/react/templates/statefulComponent.js")
     let statelessComponent = loadFile("frontend/react/templates/statelessComponent.js")
-    helpers.writeFile("./scripts/templates/statefulComponent.js", statefulComponent, "Created statefulComponent template in scripts/templates/")
-    helpers.writeFile("./scripts/templates/statelessComponent.js", statelessComponent, "Created statelessComponent template in scripts/templates/")
+    helpers.writeFile("scripts/templates/statefulComponent.js", statefulComponent, "Created statefulComponent template in scripts/templates/")
+    helpers.writeFile("scripts/templates/statelessComponent.js", statelessComponent, "Created statelessComponent template in scripts/templates/")
   }
 }
 
@@ -272,14 +272,14 @@ let addController = () => {
 
   checkScriptsFolderExists();
 
-  helpers.writeFile("./scripts/controller.js", controller, "Created controller.js script file in scripts folder");
+  helpers.writeFile("scripts/controller.js", controller, "Created controller.js script file in scripts folder");
   helpers.writeFile(
-    "./scripts/templates/controller.js",
+    "scripts/templates/controller.js",
     controllerTemplate,
     "Created controller.js template in scripts/templates"
   );
   helpers.writeFile(
-    "./scripts/templates/routes.js",
+    "scripts/templates/routes.js",
     routes,
     "Created routes.js template in scripts/templates"
   );
@@ -291,7 +291,7 @@ let addController = () => {
 let createNewScript = name => {
   helpers.addScript(name, `node scripts/${name}.js`);
   checkScriptsFolderExists();
-  helpers.writeFile(`./scripts/${name}.js`, "");
+  helpers.writeFile(`scripts/${name}.js`, "");
   prompt([template]).then(a => {
     a = a.template;
     if (a) {
@@ -300,7 +300,7 @@ let createNewScript = name => {
         let importTemplate = fs.readFileSync(path.resolve(__dirname, './templates/customScript.js'), 'utf8');
         importTemplate = importTemplate.replace(/Name/g, ans)
         helpers.appendFile(`./scripts/${name}.js`, importTemplate)
-        helpers.writeFile(`./scripts/templates/${ans}.js`, "");
+        helpers.writeFile(`scripts/templates/${ans}.js`, "");
         log("");
         log(`Added script to project, to run npm run ${name}`)
         log(`Created template ${ans} in scripts/templates`)
@@ -320,11 +320,11 @@ let checkScriptsFolderExists = () => {
   try {
     if (fs.existsSync("./scripts")) {
       if (!fs.existsSync("./scripts/templates")) {
-        helpers.mkdirSync("./scripts/templates");
+        helpers.mkdirSync("scripts/templates");
       }
     } else {
-      helpers.mkdirSync("./scripts");
-      helpers.mkdirSync("./scripts/templates");
+      helpers.mkdirSync("scripts");
+      helpers.mkdirSync("scripts/templates");
     }
   } catch (err) {
     console.error("Could not create scripts and scripts/templates folder. Here is the error: ", err)


### PR DESCRIPTION
Issue: https://github.com/blixjs/blix/issues/285

1. Checks if user supplied a name when creating a new project.
1. If they didn't prompt until we get it.
1. Store the name in the store for use throughout the project
1. In writeFile and mkdirSync helpers check if name is in store and append to file path if it is. Why? So we can remove the need for the ./${name} everywhere thus increasing the readability of certain code chunks like in new/react.js. It also means we may be able to reuse the backend.js in new/ instead of a seperate addBackend.js in add/.
1. This is basically a small but far reaching refactor. If this is stupid or unnecessary let me know.

