### PR TITLE
using exports and function expressions to improve testing

### DIFF
--- a/new/index.js
+++ b/new/index.js
@@ -38,9 +38,11 @@ const promptPreset = async () => {
     await helpers.yarn()
     react()
   } else {
-    promptFrontend()
+    this.promptFrontend()
   }
 }
+
+exports.promptPreset = promptPreset
 
 
 // prompts user to select frontend type and branches into project specific questions from there
@@ -48,16 +50,16 @@ const promptFrontend = async () => {
   const answer = await prompt([frontendOptions]);
   switch (answer.frontend) {
     case "react":
-      reactProject("react");
+      this.reactProject("react");
       break;
     case "react-router":
-      reactProject("react-router");
+      this.reactProject("react-router");
       break;
     case "redux":
-      reactProject('redux');
+      this.reactProject('redux');
       break;
     case "reactRouter-redux":
-      reactProject("reactRouter-redux")
+      this.reactProject("reactRouter-redux")
       break
     case "vue":
       vueProject("vue");
@@ -69,10 +71,12 @@ const promptFrontend = async () => {
       vanillaJSProject();
       break;
     default:
-      backendOnly();
+      this.backendOnly();
       break;
   }
 };
+
+exports.promptFrontend = promptFrontend
 
 const reactProject = async reactType => {
   store.reactType = reactType
@@ -91,6 +95,8 @@ const reactProject = async reactType => {
   await helpers.yarn()
   react();
 };
+
+exports.reactProject = reactProject
 
 const vueProject = async vueType => {
   const vueTestingSelection = await prompt([vueTesting]);
@@ -140,34 +146,29 @@ const backendOnly = async () => {
   createBackend();
 };
 
+exports.backendOnly = backendOnly
+
 const promptForName = async () => {
   let answer = await prompt([namePrompt])
   store.name = answer.name
-  createProject()
+  this.createProject()
 }
+
+exports.promptForName = promptForName
 
 // create project ensures there shouldn't be errors before starting the prompts
 const createProject = () => {
   if (!store.name) {
     console.clear()
-    promptForName()
+    this.promptForName()
     return
   }
   if (fs.existsSync(`./${store.name}`)) {
     console.error(chalk`{red A project named ${store.name} already exists!}`);
-    promptForName()
+    this.promptForName()
     return
   }
-  promptPreset()
+  this.promptPreset()
 };
 
-module.exports = {
-  createProject,
-  promptForName,
-  backendOnly,
-  vanillaJSProject,
-  vueProject,
-  reactProject,
-  promptFrontend,
-  promptPreset
-};
+exports.createProject = createProject

--- a/tests/new/index.test.js
+++ b/tests/new/index.test.js
@@ -5,28 +5,33 @@ jest.mock('fs', () => ({
 
 jest.mock('inquirer', () => ({
     prompt: jest.fn()
-  }))
+}))
 
 jest.mock('../../new/backend.js', () => ({
     createBackend: jest.fn()
 }))
 
 
-jest.mock('../../new/react.js')
+jest.mock('../../new/react.js', () => ({
+    react: jest.fn()
+}))
+
+const { react } = require('../../new/react')
+
 jest.mock('../../new/backend.js')
 
 jest.mock('../../helpers')
 
-let {
+const {
     promptPreset,
     promptFrontend,
     reactProject,
-    vueProject,
-    vanillaJSProject,
     backendOnly,
     promptForName,
     createProject
 } = require('../../new')
+
+let newModule = require('../../new')
 
 let fs = require('fs')
 
@@ -73,57 +78,57 @@ let resetStore = () => {
 describe('new/index.js', () => {
 
     describe('promptPreset', () => {
-        beforeEach(() => {
-            // resetStore()
-        })
 
         it('prompts for a preset', async () => {
-            inquirer.prompt.mockResolvedValue({preset: ''})
+            jest.spyOn(newModule, 'promptFrontend')
+            inquirer.prompt.mockResolvedValue({preset: ''}).mockResolvedValueOnce({ frontend: '' })
 
             await promptPreset()
 
             expect(inquirer.prompt).toBeCalled()
+            expect(newModule.promptFrontend).toBeCalled()
         })
 
         it('if preset is react-default set store values to react, redux, react router, with express and mongoose/mongo project', async () => {
-            inquirer.prompt.mockResolvedValue({preset: 'react-default'})      
+            inquirer.prompt.mockResolvedValueOnce({preset: 'react-default'})      
+            helpers.yarn = jest.fn()
 
             await promptPreset()
 
             expect(inquirer.prompt).toBeCalled()
             expect(store.reactType).toEqual('reactRouter-redux')
-            expect(store.reactTesting).toEqual({ enzyme: true})
+            expect(store.reactTesting).toEqual({ enzyme: true })
             expect(store.e2e).toEqual('None')
             expect(store.backend).toEqual({ backend: true })
             expect(store.serverTesting).toEqual('jest')
             expect(store.database).toEqual('mongo')
+            expect(react).toBeCalled()
         })
 
         it('prompts for yarn if yarn available', async () => {
-            inquirer.prompt.mockResolvedValue({preset: 'react-default'})    
+            inquirer.prompt.mockResolvedValueOnce({preset: 'react-default'})    
             helpers.yarn = jest.fn()
-            helpers.canUseYarn.mockResolvedValue(true)
-            inquirer.prompt.mockResolvedValueOnce({preset: 'react-default'})
+            helpers.canUseYarn.mockResolvedValueOnce(true)
 
             await promptPreset()
 
             expect(helpers.yarn).toBeCalled()
+            expect(inquirer.prompt).toBeCalled()
         })
 
         it('if manual config option selected prompt for frontend option', async () => {
-            inquirer.prompt.mockResolvedValue({ preset: 'manual' })   
+            inquirer.prompt.mockResolvedValue({ preset: 'manual' })
+            const mock = newModule.promptFrontend = jest.fn()
 
             await promptPreset()
 
-            expect(inquirer.prompt.mock.calls[1][0]).toContain(frontendOptions)
+            expect(mock).toBeCalled()
         })
     })
 
     describe('promptFrontend', () => {
 
         it('prompts for a frontend type', async () => {
-            inquirer.prompt
-                .mockResolvedValueOnce({ frontend: '' })
 
             await promptFrontend()
 
@@ -134,12 +139,14 @@ describe('new/index.js', () => {
         it('calls reactProject if react frontend selected', async () => {
             inquirer.prompt
                 .mockResolvedValueOnce({ frontend: 'react' })
+            jest.spyOn(newModule, 'reactProject')
 
             await promptFrontend()
 
             expect(inquirer.prompt).toBeCalled()
             expect(inquirer.prompt).toBeCalledWith([frontendOptions])
             expect(store.reactType).toEqual('react')
+            expect(newModule.reactProject).toBeCalledTimes(1)
         })
         
 
@@ -152,7 +159,8 @@ describe('new/index.js', () => {
             expect(inquirer.prompt).toBeCalled()
             expect(inquirer.prompt).toBeCalledWith([frontendOptions])
             expect(store.reactType).toEqual('react-router') 
-            })
+            expect(newModule.reactProject).toBeCalledTimes(1)
+        })
         
 
         it('calls reactProject if redux frontend selected', async () => {
@@ -164,6 +172,7 @@ describe('new/index.js', () => {
             expect(inquirer.prompt).toBeCalled()
             expect(inquirer.prompt).toBeCalledWith([frontendOptions])
             expect(store.reactType).toEqual('redux')
+            expect(newModule.reactProject).toBeCalledTimes(1)
         })
 
         it('calls reactProject if reactRouter-redux frontend selected', async () => {
@@ -175,23 +184,23 @@ describe('new/index.js', () => {
             expect(inquirer.prompt).toBeCalled()
             expect(inquirer.prompt).toBeCalledWith([frontendOptions])
             expect(store.reactType).toEqual('reactRouter-redux')
+            expect(newModule.reactProject).toBeCalledTimes(1)
         })
 
         it('calls backendOnly if no frontend is selected', async () => {
             helpers.yarn.mockResolvedValueOnce({ yarn: true })
             inquirer.prompt
                 .mockResolvedValueOnce({ frontend: 'none' })
-                .mockResolvedValueOnce({ linter: 'eslint' })
-                .mockResolvedValueOnce({ server: 'mocha' })
-                .mockResolvedValueOnce({ database: 'mongo' })
+            jest.spyOn(newModule, 'backendOnly')
+            
 
             await promptFrontend()
 
             expect(inquirer.prompt).toBeCalled()
             expect(inquirer.prompt).toBeCalledWith([frontendOptions])
             expect(store.backendType).toEqual('api')
+            expect(newModule.backendOnly).toBeCalledTimes(1)
         })
-        
     })
 
     describe('reactProject', () => {


### PR DESCRIPTION
@CodingItWrong by refactoring the new/index.js file to use exports.someFunction = someFunction we're now able to test via Jest spies if that function was called within the same module. Any idea why that is? 