### PR TITLE
Add error indicating no scripts were found

### DIFF
--- a/packages/cli/src/do.js
+++ b/packages/cli/src/do.js
@@ -31,6 +31,9 @@ async function runScript(directoryToSearch) {
         try {
             const packageJSON = readFileSync(`${directoryToSearch}/package.json`, "utf8")
             const scriptsObject = JSON.parse(packageJSON)["scripts"]
+
+            if (!scriptsObject) throw new ReferenceError("No scripts found.")
+
             scriptChoices.choices = Object.keys(scriptsObject).map(scriptName => {
                 return {
                     name: `${scriptName} : ${scriptsObject[scriptName]}`,


### PR DESCRIPTION
When running `blix do` from project root:

![image](https://user-images.githubusercontent.com/14250133/66274922-c4464000-e840-11e9-81a2-1f4568214892.png)
